### PR TITLE
feat(slackService): exclude self from respond

### DIFF
--- a/src/slack/slack.service.ts
+++ b/src/slack/slack.service.ts
@@ -196,10 +196,6 @@ export class SlackService {
                 this.logger.error('team not found')
                 return
             }
-            if (!(await this.isCoreTime(teamId))) {
-                this.logger.warn('Current time is not core-time')
-                return
-            }
 
             if (message.thread_ts) {
                 await this.onThreadMessage(message)
@@ -267,6 +263,11 @@ export class SlackService {
 
     @Transactional()
     private async onMessage(message: GenericMessageEvent, teamId: string, channelMembers: string[]) {
+        if (!(await this.isCoreTime(teamId))) {
+            this.logger.warn('Current time is not core-time')
+            return
+        }
+
         const slackUserId = message.user
         const user = await this.userService.findBySlackId(slackUserId)
         if (!user) {


### PR DESCRIPTION
# Description

- 스스로의 메세지에 thread_reply 혹은 emoji reaction시 이후 모든 로직을 스킵하도록 수정
- message event handler의 transaction 문제 해소