### PR TITLE
fix: restrict select option size to 100 due to slack-bolt limitation

### DIFF
--- a/src/slack/slack.service.ts
+++ b/src/slack/slack.service.ts
@@ -215,7 +215,9 @@ export class SlackService {
                                 text: {type: 'plain_text', text: channels.filter(e => e.channelId === body.channel_id)[0].name},
                                 value: body.channel_id,
                             },
-                            options: channels.map((channel): PlainTextOption => ({text: {type: 'plain_text', text: channel.name}, value: channel.channelId})),
+                            options: channels.flatMap(
+                                (channel, idx): Array<PlainTextOption> => (idx < 100 ? [{text: {type: 'plain_text', text: channel.name}, value: channel.channelId}] : []),
+                            ),
                             action_id: 'channel_select_action',
                         },
                         label: {type: 'plain_text', text: 'Channel to post'},


### PR DESCRIPTION
# Description

- slack-bot에서 select-option의 갯수를 100개로 제한하기 때문에 100개를 초과하는 채널들은 목록에서 제거함