### PR TITLE
fix: narrow update target, calculate timestamp via query

### DIFF
--- a/src/respond/dto/update-respond.dto.ts
+++ b/src/respond/dto/update-respond.dto.ts
@@ -10,6 +10,9 @@ export class UpdateRespondDto {
     @IsString()
     timestamp: string
 
-    @IsNumber()
-    timeTaken: number
+    // @IsNumber()
+    // timeTaken: number
+
+    @IsString()
+    slackTeamId: string
 }

--- a/src/slack/slack.service.ts
+++ b/src/slack/slack.service.ts
@@ -315,8 +315,14 @@ export class SlackService {
             return
         }
 
-        const timeTaken = +message.ts - +parentMessage.timestamp
-        return this.respondService.update({messageId: parentMessage.id, userId: parentMessage.user.id, timestamp: message.ts, timeTaken})
+        // const timeTaken = +message.ts - +parentMessage.timestamp
+        return this.respondService.update({
+            messageId: parentMessage.id,
+            userId: parentMessage.user.id,
+            timestamp: message.ts,
+            // timeTaken,
+            slackTeamId: parentMessage.team.teamId,
+        })
     }
 
     @SlackErrorHandler()
@@ -391,8 +397,14 @@ export class SlackService {
             return
         }
 
-        const timeTaken = +event.event_ts - +targetMessage.timestamp
-        await this.respondService.update({messageId: targetMessage.id, userId: targetMessage.user.id, timestamp: event.event_ts, timeTaken})
+        // const timeTaken = +event.event_ts - +targetMessage.timestamp
+        await this.respondService.update({
+            messageId: targetMessage.id,
+            userId: targetMessage.user.id,
+            timestamp: event.event_ts,
+            // timeTaken,
+            slackTeamId: targetMessage.team.teamId,
+        })
     }
 
     @SlackErrorHandler()


### PR DESCRIPTION
# Desc
- `respond` 업데이트 대상이 대상 메세지 이전의 모든 메세지인 점이 문제가 되어, `현재 시간 - 최대 반응 시간`이후에 등록된 반응으로 좁힘
- 걸린 시간을 일괄 부여하여 정확한 시간 계산이 되지 않는 점을 발견해, subquery를 통해 값을 가져와 계산하도록 변경

- !++ `typorm`의 `QueryBuilder`에서는 update문에서의 inner join 피처를 제공하지 않는듯 하다.